### PR TITLE
Update GitHub Actions for Tagging and Versioning

### DIFF
--- a/.github/workflows/add-tag-on-pull-request-by-bot.yaml
+++ b/.github/workflows/add-tag-on-pull-request-by-bot.yaml
@@ -1,0 +1,30 @@
+name: Add Tag on Pull Request by Bot
+
+on:
+  pull_request:
+    types: closed
+
+jobs:
+  add-tag:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Add Tag
+        run: |
+          # If the head of PR is "bot/update-version-to-<tag>", then the tag is <tag>
+          if [[ ! ${{ github.head_ref }} =~ ^bot/update-version-to-.*$ ]]; then
+            echo "PR head does not match the pattern 'bot/update-version-to-<tag>'"
+            echo "Skipping..."
+            exit 0
+          fi
+          tag=$(echo ${{ github.head_ref }} | sed -e "s:bot/update-version-to-::g")
+          echo "Tag: $tag"
+
+          # TODO: the branch name depends on check-and-fix-version-on-push-tags.yaml
+
+          # Create a tag
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a $tag -m "Add tag $tag"
+          git push -u origin $tag

--- a/.github/workflows/check-and-fix-version-on-push-tags.yaml
+++ b/.github/workflows/check-and-fix-version-on-push-tags.yaml
@@ -1,0 +1,62 @@
+name: Check and Fix Version on Push Tags
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  validate-tag:
+    uses: ./.github/workflows/validate-version-workflow-call.yaml
+    with:
+      git-ref: ${{ github.ref }}
+  update-version:
+    needs: [validate-tag]
+    if: ${{ failure() }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Update Tags
+        run: |
+          # Get the latest tag
+          export latest_tag=$(git describe --tags --abbrev=0)
+          export branch_name="bot/update-version-to-$latest_tag"
+          git checkout -b $branch_name
+
+          # Update the version
+          line_before_chg=$(grep -P "__version__ *= *['|\"]v?\d+\.\d+\.\d+.*['|\"]" runnable_family/__init__.py)
+          line_after_chg="__version__ = '$latest_tag'"
+          echo "line_before_chg: $line_before_chg"
+          echo "line_after_chg: $line_after_chg"
+          sed -i -e "s/$line_before_chg/$line_after_chg/g" runnable_family/__init__.py
+
+          # Commit and push the changes
+          if [ $(grep "$line_after_chg" runnable_family/__init__.py | wc -l) -eq 1 ]; then
+            git config --local user.name "github-actions[bot]"
+            git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add runnable_family/__init__.py
+            git commit -m "Update version to $latest_tag"
+            git push -u origin $branch_name
+            git tag -d $latest_tag
+            git push --delete origin $latest_tag
+            gh pr create \
+              --title "Update version to $latest_tag" \
+              --body "Update version to $latest_tag" \
+              --base main \
+              --head $branch_name \
+              --assignee hmasdev \
+              --reviewer hmasdev \
+              --label "bot"
+          else
+            echo "Failed to update the version"
+            exit 1
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/code-style-check-workflow-call.yaml
+++ b/.github/workflows/code-style-check-workflow-call.yaml
@@ -1,6 +1,12 @@
 name: Code Style Check
 
 on:
+  workflow_dispatch:
+    inputs:
+      git-ref:
+        required: false
+        default: "main"
+        type: string
   workflow_call:
     inputs:
       git-ref:

--- a/.github/workflows/portability-check-workflow-call.yaml
+++ b/.github/workflows/portability-check-workflow-call.yaml
@@ -1,6 +1,12 @@
 name: Portability Check
 
 on:
+  workflow_dispatch:
+    inputs:
+      git-ref:
+        required: false
+        default: "main"
+        type: string
   workflow_call:
     inputs:
       git-ref:

--- a/.github/workflows/pytest-workflow-call.yaml
+++ b/.github/workflows/pytest-workflow-call.yaml
@@ -1,6 +1,12 @@
 name: Pytest
 
 on:
+  workflow_dispatch:
+    inputs:
+      git-ref:
+        required: false
+        default: "main"
+        type: string
   workflow_call:
     inputs:
       git-ref:

--- a/.github/workflows/static-type-check-workflow-call.yaml
+++ b/.github/workflows/static-type-check-workflow-call.yaml
@@ -1,6 +1,12 @@
 name: Static Type Check
 
 on:
+  workflow_dispatch:
+    inputs:
+      git-ref:
+        required: false
+        default: "main"
+        type: string
   workflow_call:
     inputs:
       git-ref:

--- a/.github/workflows/tests-on-schedule.yaml
+++ b/.github/workflows/tests-on-schedule.yaml
@@ -1,6 +1,7 @@
 name: Scheduled Tests
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: "0 17 * * 6"
 

--- a/.github/workflows/validate-version-workflow-call.yaml
+++ b/.github/workflows/validate-version-workflow-call.yaml
@@ -1,0 +1,42 @@
+name: Validate Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      git-ref:
+        required: false
+        type: string
+        default: "main"
+  workflow_call:
+    inputs:
+      git-ref:
+        required: false
+        type: string
+        default: "main"
+
+jobs:
+  validate_version:
+    runs-on: ubuntu-latest
+    env:
+      PRIVATE_REPO_USER: "hmasdev"
+    strategy:
+      matrix:
+        python-version: ["3.11"]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.git-ref }}
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install requirements
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .
+      - name: Check Version
+        run: |
+          # Check if the tag is the same as runnable_family.__version__
+          export tag=$(echo "${{ inputs.git-ref }}" | cut -d / -f 3)
+          echo "extracted tag from git-ref: $tag"
+          python -c "import os; import runnable_family; assert runnable_family.__version__ == '$tag', (runnable_family.__version__, '$tag')"


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow files to add automated tagging and versioning functionality. The changes include:

- Updating the trigger in the GitHub Actions workflow for adding tags on pull request closure.

- Adding a new GitHub Actions workflow for checking and fixing the version on push tags.

- Modifying existing GitHub Actions workflows for code style check, portability check, pytest, static type check, and scheduled tests to include an optional input for the git reference.

These changes improve the automation and reliability of the versioning process in the project.