### PR TITLE
Update GitHub workflow permissions for write access

### DIFF
--- a/.github/workflows/add-tag-on-pull-request-by-bot.yaml
+++ b/.github/workflows/add-tag-on-pull-request-by-bot.yaml
@@ -9,7 +9,7 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - name: Add Tag

--- a/.github/workflows/check-and-fix-version-on-push-tags.yaml
+++ b/.github/workflows/check-and-fix-version-on-push-tags.yaml
@@ -17,7 +17,7 @@ jobs:
     if: ${{ failure() }}
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Modify permissions in GitHub workflows to enable write access for contents, enhancing the ability to manage repository content during actions.